### PR TITLE
suppress 'OrThrow' when matching opType

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -78,9 +78,10 @@ export function generateProcedure(
   typeName: string,
   modelName: string,
   opType: string,
+  baseOpType: string,
 ) {
   sourceFile.addStatements(/* ts */ `
-  .${getProcedureTypeByOpName(opType)}("${name}", {
+  .${getProcedureTypeByOpName(baseOpType)}("${name}", {
     input: ${typeName},
     async resolve({ ctx, input }) {
       const ${name} = await ctx.prisma.${uncapitalizeFirstLetter(

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -127,6 +127,7 @@ export async function generate(options: GeneratorOptions) {
         opNameWithModel,
         getInputTypeByOpName(baseOpType, model),
         model,
+        opType,
         baseOpType,
       );
     }

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -120,12 +120,14 @@ export async function generate(options: GeneratorOptions) {
     modelRouter.addStatements(/* ts */ `
     export const ${plural}Router = createRouter()`);
     for (const [opType, opNameWithModel] of Object.entries(operations)) {
+      const baseOpType = opType.replace('OrThrow', '');
+
       generateProcedure(
         modelRouter,
         opNameWithModel,
-        getInputTypeByOpName(opType, model),
+        getInputTypeByOpName(baseOpType, model),
         model,
-        opType,
+        baseOpType,
       );
     }
     modelRouter.formatText({ indentSize: 2 });


### PR DESCRIPTION
### Description

Removes "OrThrow" from opType string before matching in getInputTypeByOpName / getProcedureTypeByOpName.

### References

Resolves #42