### PR TITLE
feat: optional shieldPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ generator trpc {
   provider       = "prisma-trpc-generator"
   withMiddleware = false
   withShield     = false
+  shieldPath     = "../src/shield"
   contextPath       = "../src/context"
   trpcOptionsPath   = "../src/trpcOptions"
 }
@@ -176,6 +177,7 @@ model User {
 | `output`            | Output directory for the generated routers and zod schemas                 | `string`  | `./generated`                 |
 | `withMiddleware`    | Attaches a global middleware that runs before all procedures               | `boolean` | `true`                        |
 | `withShield`        | Generates a tRPC Shield to use as a permissions layer                      | `boolean` | `true`                        |
+| `shieldPath`        | Uses your existing tRPC Shield as a permissions layer                      | `string`  |                               |
 | `contextPath`       | Sets the context path used in your routers                                 | `string`  | `../../../../src/context`     |
 | `trpcOptionsPath`   | Sets the tRPC instance options                                             | `string`  | `../../../../src/trpcOptions` |
 | `isGenerateSelect`  | Enables the generation of Select related schemas and the select property   | `boolean` | `false`                       |
@@ -189,6 +191,7 @@ generator trpc {
   output             = "./trpc"
   withMiddleware     = false
   withShield         = false
+  shieldPath        = "../shield"
   contextPath        = "../context"
   trpcOptionsPath        = "../trpcOptions"
   isGenerateSelect   = true

--- a/prisma/context.ts
+++ b/prisma/context.ts
@@ -5,6 +5,7 @@ export const createContext = async ({ req, res }) => {
   const prisma = new PrismaClient();
   return {
     prisma,
+    user: null,
   };
 };
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,10 +6,11 @@ generator trpc {
   provider          = "node ./lib/generator.js"
   isGenerateSelect  = true
   isGenerateInclude = true
-  withMiddleware = true
-  withShield     = true
-  contextPath    = "./context"
-  trpcOptionsPath = "./trpcOptions"
+  withMiddleware    = true
+  withShield        = true
+  shieldPath        = "./shield"
+  contextPath       = "./context"
+  trpcOptionsPath   = "./trpcOptions"
 }
 
 datasource db {

--- a/prisma/shield.ts
+++ b/prisma/shield.ts
@@ -1,0 +1,12 @@
+import { shield, rule } from 'trpc-shield';
+import { Context } from './context';
+
+export const isAuthenticated = rule<Context>()(
+  async (ctx) => ctx.user !== null,
+);
+
+export const permissions = shield<Context>({
+  mutation: {
+    createOneBook: isAuthenticated,
+  },
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,8 @@ export const configSchema = z.object({
   withMiddleware: configBoolean.default('true'),
   withShield: configBoolean.default('true'),
   contextPath: z.string().default('../../../../src/context'),
-  trpcOptionsPath: z.string().optional()
+  trpcOptionsPath: z.string().optional(),
+  shieldPath: z.string().optional(),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,7 +6,7 @@ import getRelativePath from './utils/getRelativePath';
 import { uncapitalizeFirstLetter } from './utils/uncapitalizeFirstLetter';
 
 const getProcedureName = (config: Config) => {
-  return config.withShield
+  return config.withShield || config.shieldPath
     ? 'shieldedProcedure'
     : config.withMiddleware
     ? 'protectedProcedure'
@@ -42,10 +42,15 @@ export const generatetRPCImport = (sourceFile: SourceFile) => {
 export const generateShieldImport = (
   sourceFile: SourceFile,
   options: GeneratorOptions,
+  config: Config,
 ) => {
   const outputDir = parseEnvValue(options.generator.output as EnvValue);
+  const shieldPath = config.shieldPath
+    ? getRelativePath(outputDir, config.shieldPath, true, options.schemaPath)
+    : getRelativePath(outputDir, 'shield/shield');
+
   sourceFile.addImportDeclaration({
-    moduleSpecifier: getRelativePath(outputDir, 'shield/shield'),
+    moduleSpecifier: shieldPath,
     namedImports: ['permissions'],
   });
 };
@@ -107,7 +112,7 @@ export function generateBaseRouter(
     });
   }
 
-  if (config.withShield) {
+  if (config.withShield || config.shieldPath) {
     sourceFile.addStatements(/* ts */ `
     export const permissionsMiddleware = t.middleware(permissions);`);
     middlewares.push({

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -31,7 +31,7 @@ export async function generate(options: GeneratorOptions) {
 
   await PrismaZodGenerator(options);
 
-  if (config.withShield && !config.shieldPath) {
+  if (config.withShield) {
     const shieldOutputPath = path.join(outputDir, './shield');
     await PrismaTrpcShieldGenerator({
       ...options,

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -15,7 +15,7 @@ import {
   generateShieldImport,
   generatetRPCImport,
   getInputTypeByOpName,
-  resolveModelsComments
+  resolveModelsComments,
 } from './helpers';
 import { project } from './project';
 import removeDir from './utils/removeDir';
@@ -31,7 +31,7 @@ export async function generate(options: GeneratorOptions) {
 
   await PrismaZodGenerator(options);
 
-  if (config.withShield) {
+  if (config.withShield && !config.shieldPath) {
     const shieldOutputPath = path.join(outputDir, './shield');
     await PrismaTrpcShieldGenerator({
       ...options,
@@ -71,8 +71,8 @@ export async function generate(options: GeneratorOptions) {
   );
 
   generatetRPCImport(createRouter);
-  if (config.withShield) {
-    generateShieldImport(createRouter, options);
+  if (config.withShield || config.shieldPath) {
+    generateShieldImport(createRouter, options, config);
   }
 
   generateBaseRouter(createRouter, config, options);


### PR DESCRIPTION
### Description

Currently `withShield` generates a boilerplate configuration using `allow` for all procedures, and overwrites it on each generation.

This PR adds a new option `shieldPath` that allows your to provide a path to your own tRPC Shield to use as the permission layer. 

Alternatively, we could extend `withShield` to allow either a `boolean` (existing functionality) or a `string` path. I decided on `shieldPath` to be consistent with the other options `contextPath` and `trpcOptionsPath`.


### References

**Example input:**

- `shieldPath`: https://github.com/lottamus/prisma-trpc-generator/blob/1c5695135815b904efe59d166e818e42d05d3a6e/prisma/schema.prisma#L11
- `custom shield config`: https://github.com/lottamus/prisma-trpc-generator/blob/1c5695135815b904efe59d166e818e42d05d3a6e/prisma/shield.ts#L8

**Example output:**

`prisma/generated/routers/helpers/createRouter.ts`

<img width="589" alt="image" src="https://user-images.githubusercontent.com/7423098/218947753-bb5ddaee-432e-4ca0-ab8d-df0c3ef298bc.png">
