### PR TITLE
Add config to hide model name in procedure

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,8 @@ export const configSchema = z.object({
   withMiddleware: configBoolean.default('true'),
   withShield: configBoolean.default('true'),
   contextPath: z.string().default('../../../../src/context'),
-  trpcOptionsPath: z.string().optional()
+  trpcOptionsPath: z.string().optional(),
+  showModelNameInProcedure: configBoolean.default('true')
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -156,7 +156,7 @@ export function generateProcedure(
     input =
       '{ where: input.where, orderBy: input.orderBy, by: input.by, having: input.having, take: input.take, skip: input.skip }';
   }
-  sourceFile.addStatements(/* ts */ `${config.showModelNameInProcedure ? name :  nameWithoutModel.charAt(0).toLowerCase() + nameWithoutModel.slice(1)}: ${getProcedureName(config)}
+  sourceFile.addStatements(/* ts */ `${config.showModelNameInProcedure ? name :  nameWithoutModel}: ${getProcedureName(config)}
   .input(${typeName})
   .${getProcedureTypeByOpName(baseOpType)}(async ({ ctx, input }) => {
     const ${name} = await ctx.prisma.${uncapitalizeFirstLetter(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -156,7 +156,7 @@ export function generateProcedure(
     input =
       '{ where: input.where, orderBy: input.orderBy, by: input.by, having: input.having, take: input.take, skip: input.skip }';
   }
-  sourceFile.addStatements(/* ts */ `${name}: ${getProcedureName(config)}
+  sourceFile.addStatements(/* ts */ `${config.showModelNameInProcedure ? name :  nameWithoutModel.charAt(0).toLowerCase() + nameWithoutModel.slice(1)}: ${getProcedureName(config)}
   .input(${typeName})
   .${getProcedureTypeByOpName(baseOpType)}(async ({ ctx, input }) => {
     const ${name} = await ctx.prisma.${uncapitalizeFirstLetter(


### PR DESCRIPTION
Please see the [contributing guidelines](https://github.com/omar-dulaimi/prisma-trpc-generator/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds an optional boolean configuration variable for the generator called `showModelNameInProcedure` which is `true` by default.

When enabled the generated output is slightly modified - instead of getting names like this:

- `findFirstX`
- `deleteOneX`
- `createOneX`

The model name "X" is removed leaving only:

- `findFirst`
- `deleteOne`
- `createOne`

The reason I think people may like this (I do personally) is that the tRPC router name itself provides the context of what object you're mutating or querying.

`userRouter.findFirst({ where: { id: 1 } })` reads perfectly fine wheras `userRouter.findFirstUser({ where: { id: 1 } })` seems overly verbose.

Interested to hear your thoughts!

### References

Discussion thread:

- #63 
