### PR TITLE
Add config option to enable specific model actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,15 +171,16 @@ model User {
 
 # Additional Options
 
-| Option              | Description                                                                | Type      | Default                       |
-| ------------------- | -------------------------------------------------------------------------- | --------- | ----------------------------- |
-| `output`            | Output directory for the generated routers and zod schemas                 | `string`  | `./generated`                 |
-| `withMiddleware`    | Attaches a global middleware that runs before all procedures               | `boolean` | `true`                        |
-| `withShield`        | Generates a tRPC Shield to use as a permissions layer                      | `boolean` | `true`                        |
-| `contextPath`       | Sets the context path used in your routers                                 | `string`  | `../../../../src/context`     |
-| `trpcOptionsPath`   | Sets the tRPC instance options                                             | `string`  | `../../../../src/trpcOptions` |
-| `isGenerateSelect`  | Enables the generation of Select related schemas and the select property   | `boolean` | `false`                       |
-| `isGenerateInclude` | Enables the generation of Include related schemas and the include property | `boolean` | `false`                       |
+| Option                 | Description                                                                | Type      | Default                                                                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `output`               | Output directory for the generated routers and zod schemas                 | `string`  | `./generated`                                                                                                                                                                |
+| `withMiddleware`       | Attaches a global middleware that runs before all procedures               | `boolean` | `true`                                                                                                                                                                       |
+| `withShield`           | Generates a tRPC Shield to use as a permissions layer                      | `boolean` | `true`                                                                                                                                                                       |
+| `contextPath`          | Sets the context path used in your routers                                 | `string`  | `../../../../src/context`                                                                                                                                                    |
+| `trpcOptionsPath`      | Sets the tRPC instance options                                             | `string`  | `../../../../src/trpcOptions`                                                                                                                                                |
+| `isGenerateSelect`     | Enables the generation of Select related schemas and the select property   | `boolean` | `false`                                                                                                                                                                      |
+| `isGenerateInclude`    | Enables the generation of Include related schemas and the include property | `boolean` | `false`                                                                                                                                                                      |
+| `generateModelActions` | Enables the generation of specific model actions                           | `string`  | `aggregate,aggregateRaw,count,create,createMany,delete,deleteMany,findFirst,findFirstOrThrow,findMany,findRaw,findUnique,findUniqueOrThrow,groupBy,update,updateMany,upsert` |
 
 Use additional options in the `schema.prisma`
 
@@ -193,5 +194,6 @@ generator trpc {
   trpcOptionsPath        = "../trpcOptions"
   isGenerateSelect   = true
   isGenerateInclude  = true
+  generateModelActions = "aggregate,aggregateRaw,count,create,createMany,delete,deleteMany,findFirst,findFirstOrThrow,findMany,findRaw,findUnique,findUniqueOrThrow,groupBy,update,updateMany,upsert"
 }
 ```

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,10 +6,10 @@ generator trpc {
   provider          = "node ./lib/generator.js"
   isGenerateSelect  = true
   isGenerateInclude = true
-  withMiddleware = true
-  withShield     = true
-  contextPath    = "./context"
-  trpcOptionsPath = "./trpcOptions"
+  withMiddleware    = true
+  withShield        = true
+  contextPath       = "./context"
+  trpcOptionsPath   = "./trpcOptions"
 }
 
 datasource db {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,14 +1,25 @@
+import { DMMF } from '@prisma/generator-helper';
 import { z } from 'zod';
 
 const configBoolean = z
   .enum(['true', 'false'])
   .transform((arg) => JSON.parse(arg));
 
+const modelActionEnum = z.nativeEnum(DMMF.ModelAction);
+
 export const configSchema = z.object({
   withMiddleware: configBoolean.default('true'),
   withShield: configBoolean.default('true'),
   contextPath: z.string().default('../../../../src/context'),
-  trpcOptionsPath: z.string().optional()
+  trpcOptionsPath: z.string().optional(),
+  generateModelActions: z
+    .string()
+    .default(Object.values(DMMF.ModelAction).join(','))
+    .transform((arg) => {
+      return arg
+        .split(',')
+        .map((action) => modelActionEnum.parse(action.trim()));
+    }),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -168,42 +168,33 @@ export function generateProcedure(
 
 export function generateRouterSchemaImports(
   sourceFile: SourceFile,
-  name: string,
-  hasCreateMany: boolean,
-  provider: string,
+  modelName: string,
+  modelActions: string[],
 ) {
-  let statements = [
-    `import { ${name}FindUniqueSchema } from "../schemas/findUnique${name}.schema";`,
-    `import { ${name}FindFirstSchema } from "../schemas/findFirst${name}.schema";`,
-    `import { ${name}FindManySchema } from "../schemas/findMany${name}.schema";`,
-    `import { ${name}CreateOneSchema } from "../schemas/createOne${name}.schema";`,
-  ];
-
-  if (hasCreateMany) {
-    statements.push(
-      `import { ${name}CreateManySchema } from "../schemas/createMany${name}.schema";`,
-    );
-  }
-
-  statements = statements.concat([
-    `import { ${name}DeleteOneSchema } from "../schemas/deleteOne${name}.schema";`,
-    `import { ${name}UpdateOneSchema } from "../schemas/updateOne${name}.schema";`,
-    `import { ${name}DeleteManySchema } from "../schemas/deleteMany${name}.schema";`,
-    `import { ${name}UpdateManySchema } from "../schemas/updateMany${name}.schema";`,
-    `import { ${name}UpsertSchema } from "../schemas/upsertOne${name}.schema";`,
-    `import { ${name}AggregateSchema } from "../schemas/aggregate${name}.schema";`,
-    `import { ${name}GroupBySchema } from "../schemas/groupBy${name}.schema";`,
-  ]);
-
-  if (provider === 'mongodb') {
-    statements = statements.concat([
-      `import { ${name}FindRawObjectSchema } from "../schemas/objects/${name}FindRaw.schema";`,
-      `import { ${name}AggregateRawObjectSchema } from "../schemas/objects/${name}AggregateRaw.schema";`,
-    ]);
-  }
-
-  sourceFile.addStatements(/* ts */ statements.join('\n'));
+  sourceFile.addStatements(
+    /* ts */
+    [
+      // remove any duplicate import statements
+      ...new Set(
+        modelActions.map((opName) =>
+          getRouterSchemaImportByOpName(opName, modelName),
+        ),
+      ),
+    ].join('\n'),
+  );
 }
+
+export const getRouterSchemaImportByOpName = (
+  opName: string,
+  modelName: string,
+) => {
+  const opType = opName.replace('OrThrow', '');
+  const inputType = getInputTypeByOpName(opType, modelName);
+
+  return inputType
+    ? `import { ${inputType} } from "../schemas/${opType}${modelName}.schema";`
+    : '';
+};
 
 export const getInputTypeByOpName = (opName: string, modelName: string) => {
   let inputType;


### PR DESCRIPTION
### Description

Currently, we're generating a route for every possible model action, sometimes resulting in unused code. 

This PR adds an optional config to enable specific model actions. 

Example Input:

```prisma
generator trpc {
  provider           = "prisma-trpc-generator"
  generateModelActions = "create,delete,findFirst,findMany,findUnique,update,upsert"
}
```

Example output:

<img width="679" alt="image" src="https://user-images.githubusercontent.com/7423098/220001099-a28a2e26-14b4-4da7-9e8d-00b548ed23a1.png">


### References

It would be much nicer to allow providing an array for `generateModelActions`, however it seems this currently is not possible: https://github.com/prisma/prisma/issues/9511

### Other

We could also expose this functionality at the model level too

```prisma
/// @@Gen.model(actions: [create,delete,findFirst,findMany,findUnique,update,upsert])
model User {
  id    Int     @id @default(autoincrement())
  email String  @unique
  name  String?
  posts Post[]
  books Book[]
}
```
