### PR TITLE
Add option to provide middleware file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@
 
 - [About The Project](#about-the-project)
 - [Supported Prisma Versions](#supported-prisma-versions)
-    - [Prisma 4](#prisma-4)
-    - [Prisma 2/3](#prisma-23)
+  - [Prisma 4](#prisma-4)
+  - [Prisma 2/3](#prisma-23)
 - [Supported tRPC Versions](#supported-trpc-versions)
-    - [tRPC 10](#trpc-10)
-    - [tRPC 9](#trpc-9)
+  - [tRPC 10](#trpc-10)
+  - [tRPC 9](#trpc-9)
 - [Installation](#installation)
 - [Usage](#usage)
 - [Customizations](#customizations)
@@ -172,9 +172,9 @@ model User {
 # Additional Options
 
 | Option                     | Description                                                                            | Type      | Default                                                                                                                                                                      |
-| -------------------------- | -------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| -------------------------- | -------------------------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
 | `output`                   | Output directory for the generated routers and zod schemas                             | `string`  | `./generated`                                                                                                                                                                |
-| `withMiddleware`           | Attaches a global middleware that runs before all procedures                           | `boolean` | `true`                                                                                                                                                                       |
+| `withMiddleware`           | Attaches a global middleware that runs before all procedures                           | `boolean  | string`                                                                                                                                                                      | `true` |
 | `withShield`               | Generates a tRPC Shield to use as a permissions layer                                  | `boolean` | `true`                                                                                                                                                                       |
 | `contextPath`              | Sets the context path used in your routers                                             | `string`  | `../../../../src/context`                                                                                                                                                    |
 | `trpcOptionsPath`          | Sets the tRPC instance options                                                         | `string`  | `../../../../src/trpcOptions`                                                                                                                                                |
@@ -183,14 +183,13 @@ model User {
 | `showModelNameInProcedure` | When disabled, the generated procedure no longer includes the name of the Prisma model | `boolean` | `true`                                                                                                                                                                       |
 | `generateModelActions`     | Enables the generation of specific model actions                                       | `string`  | `aggregate,aggregateRaw,count,create,createMany,delete,deleteMany,findFirst,findFirstOrThrow,findMany,findRaw,findUnique,findUniqueOrThrow,groupBy,update,updateMany,upsert` |
 
-
 Use additional options in the `schema.prisma`
 
 ```prisma
 generator trpc {
   provider           = "prisma-trpc-generator"
   output             = "./trpc"
-  withMiddleware     = false
+  withMiddleware     = "../middleware"
   withShield         = false
   contextPath        = "../context"
   trpcOptionsPath    = "../trpcOptions"

--- a/prisma/middleware.ts
+++ b/prisma/middleware.ts
@@ -1,0 +1,4 @@
+export default async ({ ctx, next }) => {
+  console.log("Hello from the imported Middleware");
+  return next({ ctx });
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -6,7 +6,7 @@ generator trpc {
   provider          = "node ./lib/generator.js"
   isGenerateSelect  = true
   isGenerateInclude = true
-  withMiddleware    = true
+  withMiddleware    = "./middleware"
   withShield        = true
   contextPath       = "./context"
   trpcOptionsPath   = "./trpcOptions"

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,10 +5,12 @@ const configBoolean = z
   .enum(['true', 'false'])
   .transform((arg) => JSON.parse(arg));
 
+const configStringOrBoolean = z.union([configBoolean, z.string().default("../../../../src/middleware")])
+
 const modelActionEnum = z.nativeEnum(DMMF.ModelAction);
 
 export const configSchema = z.object({
-  withMiddleware: configBoolean.default('true'),
+  withMiddleware: configStringOrBoolean.default('true'),
   withShield: configBoolean.default('true'),
   contextPath: z.string().default('../../../../src/context'),
   trpcOptionsPath: z.string().optional(),

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -228,46 +228,46 @@ export const getInputTypeByOpName = (opName: string, modelName: string) => {
   let inputType;
   switch (opName) {
     case 'findUnique':
-      inputType = `${modelName} FindUniqueSchema`;
+      inputType = `${modelName}FindUniqueSchema`;
       break;
     case 'findFirst':
-      inputType = `${modelName} FindFirstSchema`;
+      inputType = `${modelName}FindFirstSchema`;
       break;
     case 'findMany':
-      inputType = `${modelName} FindManySchema`;
+      inputType = `${modelName}FindManySchema`;
       break;
     case 'findRaw':
-      inputType = `${modelName} FindRawObjectSchema`;
+      inputType = `${modelName}FindRawObjectSchema`;
       break;
     case 'createOne':
-      inputType = `${modelName} CreateOneSchema`;
+      inputType = `${modelName}CreateOneSchema`;
       break;
     case 'createMany':
-      inputType = `${modelName} CreateManySchema`;
+      inputType = `${modelName}CreateManySchema`;
       break;
     case 'deleteOne':
-      inputType = `${modelName} DeleteOneSchema`;
+      inputType = `${modelName}DeleteOneSchema`;
       break;
     case 'updateOne':
-      inputType = `${modelName} UpdateOneSchema`;
+      inputType = `${modelName}UpdateOneSchema`;
       break;
     case 'deleteMany':
-      inputType = `${modelName} DeleteManySchema`;
+      inputType = `${modelName}DeleteManySchema`;
       break;
     case 'updateMany':
-      inputType = `${modelName} UpdateManySchema`;
+      inputType = `${modelName}UpdateManySchema`;
       break;
     case 'upsertOne':
-      inputType = `${modelName} UpsertSchema`;
+      inputType = `${modelName}UpsertSchema`;
       break;
     case 'aggregate':
-      inputType = `${modelName} AggregateSchema`;
+      inputType = `${modelName}AggregateSchema`;
       break;
     case 'aggregateRaw':
-      inputType = `${modelName} AggregateRawObjectSchema`;
+      inputType = `${modelName}AggregateRawObjectSchema`;
       break;
     case 'groupBy':
-      inputType = `${modelName} GroupBySchema`;
+      inputType = `${modelName}GroupBySchema`;
       break;
     default:
       console.log('getInputTypeByOpName: ', { opName, modelName });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,7 +1,6 @@
 import { DMMF, EnvValue, GeneratorOptions } from '@prisma/generator-helper';
 import { parseEnvValue } from '@prisma/internals';
 import { SourceFile } from 'ts-morph';
-import { z } from 'zod';
 import { Config } from './config';
 import getRelativePath from './utils/getRelativePath';
 import { uncapitalizeFirstLetter } from './utils/uncapitalizeFirstLetter';


### PR DESCRIPTION
### Description
To prevent having to rewrite the middleware after a regeneration the `withMiddleware` option also accepts a path to a file with a default export.

If the merged option does not float your boat i can split this into two options with a `middleware` key overriding the `withMiddleware` option if set and only accepting a path to the respective file.

P.S.: Sorry for the autoformatting, it seems VS Code did not register the `.prettierrc`.
