### PR TITLE
Import only type of Context

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -79,7 +79,7 @@ export function generateBaseRouter(
 ) {
   const outputDir = parseEnvValue(options.generator.output as EnvValue);
   sourceFile.addStatements(/* ts */ `
-  import { Context } from '${getRelativePath(
+  import type { Context } from '${getRelativePath(
     outputDir,
     config.contextPath,
     true,


### PR DESCRIPTION
Context is only used as a type import in the generated createRouter file (`export const t = trpc.initTRPC.context<Context>().create();`) which generates an ESLint warning (@typescript-eslint/consistent-type-imports) for me. I think this PR should fix it but I didn't look into it much further so please confirm for yourself if this PR actually fixes the problem.
