### PR TITLE
feat(shield): withShield optional string path

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ model User {
 | `withMiddleware`           | Attaches a global middleware that runs before all procedures                           | `boolean or string`| `true`                                                                                                                                                              |
 | `output`                   | Output directory for the generated routers and zod schemas                             | `string`  | `./generated`                                                                                                                                                                |
 | `withZod`                  |  Use Zod for input validation                                                          | `boolean` | `true`                                                                                                                                                                       |
-| `withShield`               | Generates a tRPC Shield to use as a permissions layer                                  | `boolean` | `true`                                                                                                                                                                       |
+| `withShield`               | Generates a tRPC Shield to use as a permissions layer                                  | `boolean or string` | `true`                                                                                                                                                                       |
 | `contextPath`              | Sets the context path used in your routers                                             | `string`  | `../../../../src/context`                                                                                                                                                    |
 | `trpcOptionsPath`          | Sets the tRPC instance options                                                         | `string`  | `../../../../src/trpcOptions`                                                                                                                                                |
 | `isGenerateSelect`         | Enables the generation of Select related schemas and the select property               | `boolean` | `false`                                                                                                                                                                      |
@@ -193,7 +193,7 @@ generator trpc {
   provider           = "prisma-trpc-generator"
   output             = "./trpc"
   withMiddleware     = "../middleware"
-  withZod            = false 
+  withZod            = false
   withShield         = false
   contextPath        = "../context"
   trpcOptionsPath    = "../trpcOptions"

--- a/prisma/context.ts
+++ b/prisma/context.ts
@@ -5,6 +5,7 @@ export const createContext = async ({ req, res }) => {
   const prisma = new PrismaClient();
   return {
     prisma,
+    user: null,
   };
 };
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator trpc {
   isGenerateSelect  = true
   isGenerateInclude = true
   withMiddleware    = "./middleware"
-  withShield        = true
+  withShield        = "./shield"
   contextPath       = "./context"
   trpcOptionsPath   = "./trpcOptions"
 }

--- a/prisma/shield.ts
+++ b/prisma/shield.ts
@@ -1,0 +1,12 @@
+import { shield, rule } from 'trpc-shield';
+import { Context } from './context';
+
+export const isAuthenticated = rule<Context>()(
+  async (ctx) => ctx.user !== null,
+);
+
+export const permissions = shield<Context>({
+  mutation: {
+    createOneBook: isAuthenticated,
+  },
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,13 +5,21 @@ const configBoolean = z
   .enum(['true', 'false'])
   .transform((arg) => JSON.parse(arg));
 
-const configStringOrBoolean = z.union([configBoolean, z.string().default("../../../../src/middleware")])
+const configMiddleware = z.union([
+  configBoolean,
+  z.string().default('../../../../src/middleware'),
+]);
+
+const configShield = z.union([
+  configBoolean,
+  z.string().default('../../../../src/shield'),
+]);
 
 const modelActionEnum = z.nativeEnum(DMMF.ModelAction);
 
 export const configSchema = z.object({
-  withMiddleware: configStringOrBoolean.default('true'),
-  withShield: configBoolean.default('true'),
+  withMiddleware: configMiddleware.default('true'),
+  withShield: configShield.default('true'),
   withZod: configBoolean.default('true'),
   contextPath: z.string().default('../../../../src/context'),
   trpcOptionsPath: z.string().optional(),
@@ -23,7 +31,7 @@ export const configSchema = z.object({
       return arg
         .split(',')
         .map((action) => modelActionEnum.parse(action.trim()));
-    })
+    }),
 });
 
 export type Config = z.infer<typeof configSchema>;

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -33,7 +33,7 @@ export async function generate(options: GeneratorOptions) {
     await PrismaZodGenerator(options);
   }
 
-  if (config.withShield) {
+  if (config.withShield === true) {
     const shieldOutputPath = path.join(outputDir, './shield');
     await PrismaTrpcShieldGenerator({
       ...options,

--- a/src/prisma-generator.ts
+++ b/src/prisma-generator.ts
@@ -15,7 +15,7 @@ import {
   generateShieldImport,
   generatetRPCImport,
   getInputTypeByOpName,
-  resolveModelsComments
+  resolveModelsComments,
 } from './helpers';
 import { project } from './project';
 import removeDir from './utils/removeDir';
@@ -72,7 +72,7 @@ export async function generate(options: GeneratorOptions) {
 
   generatetRPCImport(createRouter);
   if (config.withShield) {
-    generateShieldImport(createRouter, options);
+    generateShieldImport(createRouter, options, config.withShield);
   }
 
   generateBaseRouter(createRouter, config, options);


### PR DESCRIPTION
This is https://github.com/omar-dulaimi/prisma-trpc-generator/pull/65 but addressing @omar-dulaimi's comments of consistency with `string | boolean` pattern.

cc: @lottamus 

### Description

When `withShield` is `true`, 
```
generator trpc {
  ...
  withShield = true
}
```

We generate a boilerplate configuration using allow for all procedures and we overwrite this file on each generation.

It looks something like this:
```
import { shield, allow } from 'trpc-shield';
import { Context } from '../../context';

export const permissions = shield<Context>({
  query: {
    aggregate: allow,
    ...
  },
  mutation: {
    create: allow,
    ...
  },
});
```

This pull request updates the option `withShield` to allow a string path to your own tRPC Shield to use as the permission layer.

Similarly to `withMiddleware`, this will extend `withShield` to allow either a boolean or a string path.

When `withShield` is a `string` path:
```
generator trpc {
  ...
  withShield = "../../libs/shield"
}
```

The `routers/helpers/createRouter.ts` will use the path instead:
```
import { permissions } from "../../libs/shield";
```