### PR TITLE
fix: update prisma-zod-generator to 1.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@prisma/internals": "^6.12.0",
         "pluralize": "^8.0.0",
         "prisma-trpc-shield-generator": "0.2.0",
-        "prisma-zod-generator": "^1.0.6",
+        "prisma-zod-generator": "^1.0.7",
         "ts-morph": "^26.0.0",
         "tslib": "^2.8.1"
       },
@@ -8672,9 +8672,9 @@
       }
     },
     "node_modules/prisma-zod-generator": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/prisma-zod-generator/-/prisma-zod-generator-1.0.6.tgz",
-      "integrity": "sha512-DR+7gmZ3ScBkLzvWsWkIA/tcbJNPeh4EjvVxdXHC4GzGcWKFK6/MaHGURg+69b1hGJZ54PSMIyDyQEQanw/agA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/prisma-zod-generator/-/prisma-zod-generator-1.0.7.tgz",
+      "integrity": "sha512-VpWodvVnqnEDfWnpSouinTcBKmeO9jSLDkpnCLcKGN1gkK5WhzKzaSocyIQySkkx2YbJXNWn9PVJTy3qvXsufg==",
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^6.12.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@prisma/internals": "^6.12.0",
     "pluralize": "^8.0.0",
     "prisma-trpc-shield-generator": "0.2.0",
-    "prisma-zod-generator": "^1.0.6",
+    "prisma-zod-generator": "^1.0.7",
     "ts-morph": "^26.0.0",
     "tslib": "^2.8.1"
   },


### PR DESCRIPTION
## Summary
• Updates prisma-zod-generator dependency from 1.0.6 to 1.0.7
• Fixes issues on their side with the latest upstream bug fixes

## Test plan
- [x] Dependency updated successfully
- [x] Package installed without issues
- [ ] Run existing tests to ensure compatibility
- [ ] Verify generator still works as expected

🤖 Generated with automated dependency management