### PR TITLE
Make trpcOptionsPath optional by default

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -94,7 +94,9 @@ export const configSchema = z.object({
   // tRPC metadata support for OpenAPI, auth, descriptions, etc.
   withMeta: configMeta.optional().default(false),
   contextPath: z.string().default('../../../../src/context'),
-  // Optional path to custom tRPC init options module
+  // Keep this opt-in: a hardcoded default import can break ESM projects when
+  // the generated relative path does not exist. Optional-by-default keeps
+  // generation portable and only imports trpcOptions when explicitly configured.
   trpcOptionsPath: z.string().optional(),
   // Postman collection emission
   postman: z

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,9 +94,7 @@ export const configSchema = z.object({
   // tRPC metadata support for OpenAPI, auth, descriptions, etc.
   withMeta: configMeta.optional().default(false),
   contextPath: z.string().default('../../../../src/context'),
-  // Keep this opt-in: a hardcoded default import can break ESM projects when
-  // the generated relative path does not exist. Optional-by-default keeps
-  // generation portable and only imports trpcOptions when explicitly configured.
+  // Optional path to custom tRPC init options module
   trpcOptionsPath: z.string().optional(),
   // Postman collection emission
   postman: z

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,8 +94,8 @@ export const configSchema = z.object({
   // tRPC metadata support for OpenAPI, auth, descriptions, etc.
   withMeta: configMeta.optional().default(false),
   contextPath: z.string().default('../../../../src/context'),
-  // README default
-  trpcOptionsPath: z.string().optional().default('../../../../src/trpcOptions'),
+  // Optional path to custom tRPC init options module
+  trpcOptionsPath: z.string().optional(),
   // Postman collection emission
   postman: z
     .union([

--- a/tests/feature-trpc-options-path.test.ts
+++ b/tests/feature-trpc-options-path.test.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { generateRouters, readFileSafe } from './utils/generate';
+
+describe('feature: trpcOptionsPath', () => {
+  it('does not import trpcOptions when trpcOptionsPath is omitted', () => {
+    const outDir = generateRouters('trpc-options-path', {
+      trpcOptionsPath: undefined,
+    });
+    const helpersPath = join(outDir, 'routers', 'helpers', 'createRouter.ts');
+    expect(fs.existsSync(helpersPath)).toBe(true);
+    const content = readFileSafe(helpersPath);
+    expect(content).not.toContain('import trpcOptions');
+    expect(content).toContain('initTRPC.context<Context>().create()');
+  });
+});

--- a/tests/utils/generate.ts
+++ b/tests/utils/generate.ts
@@ -9,6 +9,7 @@ export type GenOverrides = Partial<{
   auth: boolean;
   postman: boolean;
   openapi: boolean;
+  trpcOptionsPath: string;
 }>;
 
 /**


### PR DESCRIPTION
## Summary
- remove the hardcoded default for `trpcOptionsPath`
- only import/use `trpcOptions` when the path is explicitly configured
- add a focused test covering the omitted-path case

## Test plan
- pnpm exec tsc
- pnpm exec vitest run tests/feature-trpc-options-path.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * tRPC initialization options path is now optional and no longer falls back to a built-in default.
* **Tests**
  * Added test coverage for handling an undefined tRPC options path.
  * Test utilities extended to allow passing a custom tRPC options path for generation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->